### PR TITLE
Unit tests return... with a fix

### DIFF
--- a/LibUnitTest/LibUnitTest.vcxproj
+++ b/LibUnitTest/LibUnitTest.vcxproj
@@ -94,8 +94,12 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="stdafx.h" />
+    <ClInclude Include="targetver.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="PlayFabClientTest.cpp" />
+    <ClCompile Include="PlayFabEntityTest.cpp" />
+    <ClCompile Include="PlayFabServerTest.cpp" />
     <ClCompile Include="stdafx.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
@@ -121,6 +125,13 @@
     <Import Project="..\packages\libssh2.1.4.3.3\build\native\libssh2.targets" Condition="Exists('..\packages\libssh2.1.4.3.3\build\native\libssh2.targets')" />
     <Import Project="..\packages\curl.7.30.0.2\build\native\curl.targets" Condition="Exists('..\packages\curl.7.30.0.2\build\native\curl.targets')" />
   </ImportGroup>
+  <Target Name="CopyDependencies" AfterTargets="AfterBuild">
+    <ItemGroup>
+      <Dependency Include="$(TFS_BinariesDirectory)\$(Configuration)\$(Platform)\XPlatCppWindows\*.dll" />
+      <Dependency Include="$(SolutionDir)$(Platform)\$(Configuration)\XPlatCppWindows\*.dll" />
+    </ItemGroup>
+    <Copy SourceFiles="@(Dependency)" DestinationFolder="$(OutDir)" SkipUnchangedFiles="true" />
+  </Target>  
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>

--- a/LibUnitTest/LibUnitTest.vcxproj.filters
+++ b/LibUnitTest/LibUnitTest.vcxproj.filters
@@ -18,9 +18,21 @@
     <ClInclude Include="stdafx.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="targetver.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="stdafx.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="PlayFabClientTest.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="PlayFabEntityTest.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="PlayFabServerTest.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/LibUnitTest/PlayFabClientTest.cpp
+++ b/LibUnitTest/PlayFabClientTest.cpp
@@ -131,7 +131,7 @@ namespace UnittestRunner
             testMessageReturn = "API_Call_Failed for: ";
             testMessageReturn += error.UrlPath;
             testMessageReturn += "\n";
-            testMessageReturn += error.GenerateReport();
+            testMessageReturn += error.GenerateErrorReport();
             testMessageReturn += "\n";
             testMessageReturn += error.Request.toStyledString();
         }
@@ -206,7 +206,7 @@ namespace UnittestRunner
             bool foundEmailMsg, foundPasswordMsg;
             string expectedEmailMsg = "Email address is not valid.";
             string expectedPasswordMsg = "Password must be between";
-            string errorConcat = error.GenerateReport();
+            string errorConcat = error.GenerateErrorReport();
             foundEmailMsg = (errorConcat.find(expectedEmailMsg) != -1);
             foundPasswordMsg = (errorConcat.find(expectedPasswordMsg) != -1);
 
@@ -476,7 +476,7 @@ namespace UnittestRunner
             if (result.FunctionResult.isNull())
                 testMessageReturn = "Cloud Decode Failure";
             else if (!result.Error.isNull())
-                testMessageReturn = result.Error.mValue.Message;
+                testMessageReturn = result.Error->Message;
             else
                 testMessageReturn = result.FunctionResult["messageValue"].asString();
         }

--- a/LibUnitTest/PlayFabServerTest.cpp
+++ b/LibUnitTest/PlayFabServerTest.cpp
@@ -113,7 +113,7 @@ namespace UnittestRunner
             testMessageReturn = "API_Call_Failed for: ";
             testMessageReturn += error.UrlPath;
             testMessageReturn += "\n";
-            testMessageReturn += error.GenerateReport();
+            testMessageReturn += error.GenerateErrorReport();
             testMessageReturn += "\n";
             testMessageReturn += error.Request.toStyledString();
         }
@@ -139,7 +139,7 @@ namespace UnittestRunner
             if (result.FunctionResult.isNull())
                 testMessageReturn = "Cloud Decode Failure";
             else if (!result.Error.isNull())
-                testMessageReturn = result.Error.mValue.Message;
+                testMessageReturn = result.Error->Message;
             else
                 testMessageReturn = result.FunctionResult["messageValue"].asString();
         }


### PR DESCRIPTION
- Bringing unit tests back to Xplat C++ SDK
- A small fix copies all necessary DLL dependencies to the output folder