### PR TITLE
XPlatSocket: fix broken setsockopt() call on Windows

### DIFF
--- a/code/source/playfab/QoS/XPlatSocket.cpp
+++ b/code/source/playfab/QoS/XPlatSocket.cpp
@@ -86,7 +86,14 @@ namespace PlayFab
             // tv_usec takes microseconds, hence convert the input milliseconds to microseconds
             timeOutVal.tv_usec = (timeoutMs - timeOutVal.tv_sec * 1000) * 1000;
 #if defined(PLAYFAB_PLATFORM_WINDOWS) || defined(PLAYFAB_PLATFORM_XBOX)
-            return setsockopt(s, SOL_SOCKET, SO_RCVTIMEO | SO_SNDTIMEO, reinterpret_cast<const char*>(&timeoutMs), sizeof(timeoutMs));
+            int errorCode = setsockopt(s, SOL_SOCKET, SO_RCVTIMEO, reinterpret_cast<const char*>(&timeoutMs), sizeof(timeoutMs));
+
+            if (errorCode == 0)
+            {
+                errorCode = setsockopt(s, SOL_SOCKET, SO_SNDTIMEO, reinterpret_cast<const char*>(&timeoutMs), sizeof(timeoutMs));
+            }
+
+            return errorCode;
 #else
             return setsockopt(s, SOL_SOCKET, SO_RCVTIMEO, (struct timeval *) &timeOutVal, sizeof(struct timeval));
 #endif


### PR DESCRIPTION
`XPlatSocket::SetTimeout()` is currently implemented on Windows as a single call to [`setsockopt()`][1] that sets both `SO_RCVTIMEO` (receive timeout) and `SO_SNDTIMEO` (send timeout). We bitwise OR the two option constants together and pass the result as `optname`.

That's incorrect and cannot work, however. Socket option constants are not bitmasks, and `setsockopt()` has no ability to set multiple options in one call. (That functionality wouldn't be useful in most cases anyway because each option interprets `optval` differently.)

What we're actually doing is ORing together 0x1006 ([`SO_RCVTIMEO`][2]) and 0x1005 ([`SO_SNDTIMEO`][3]) for a result of 0x1007, which is [`SO_ERROR`][4], a completely separate option that's unrelated to any sort of timeout and is documented to work only with `getsockopt()`, not `setsockopt()`.

Windows seems to silently ignore the error and report success, but WINE reports an error for this incorrect usage, which prevents any QoS functionality of the SDK from working when running under WINE. This problem manifested for me as Microsoft Flight Simulator failing to enable live traffic and multiplayer when running under Valve's Proton, which is based on WINE.

Fix the issue by separating the broken call into two separate calls, one for each option we set.

Note that I have compile-tested this fix, but I was not able to test that it's functionally correct because the examples in this repository seem to require real accounts on the PlayFab backend, which I didn't want to try and set up for a simple bug fix like this.

[1]: https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-setsockopt
[2]: https://www.magnumdb.com/search?q=SO_RCVTIMEO
[3]: https://www.magnumdb.com/search?q=SO_SNDTIMEO
[4]: https://www.magnumdb.com/search?q=SO_ERROR