### PR TITLE
[Linux] Fix Debug-only segfaults by replacing Json::Value::null with Json::Value()

### DIFF
--- a/code/include/playfab/PlayFabBaseModel.h
+++ b/code/include/playfab/PlayFabBaseModel.h
@@ -83,7 +83,7 @@ namespace PlayFab
     }
     inline void FromJsonUtilT(const Json::Value& input, time_t& output)
     {
-        if (input == Json::Value::null)
+        if (input == Json::Value())
         {
             return;
         }
@@ -104,7 +104,7 @@ namespace PlayFab
 
     inline void FromJsonUtilT(const Json::Value& input, Boxed<time_t>& output)
     {
-        if (input == Json::Value::null)
+        if (input == Json::Value())
         {
             output.setNull();
         }
@@ -120,7 +120,7 @@ namespace PlayFab
     {
         if (input.size() == 0)
         {
-            output = Json::Value::null;
+            output = Json::Value();
         }
         else
         {
@@ -138,7 +138,7 @@ namespace PlayFab
     inline void FromJsonUtilT(const Json::Value& input, std::list<time_t>& output)
     {
         output.clear();
-        if (input == Json::Value::null || !input.isArray())
+        if (input == Json::Value() || !input.isArray())
         {
             return;
         }
@@ -165,7 +165,7 @@ namespace PlayFab
     inline void FromJsonUtilT(const Json::Value& input, std::map<std::string, time_t>& output)
     {
         output.clear();
-        if (input == Json::Value::null)
+        if (input == Json::Value())
         {
             return;
         }
@@ -193,7 +193,7 @@ namespace PlayFab
 
     template <typename EnumType> inline void FromJsonUtilE(const Json::Value& input, Boxed<EnumType>& output)
     {
-        if (input == Json::Value::null)
+        if (input == Json::Value())
         {
             output.setNull();
         }
@@ -209,7 +209,7 @@ namespace PlayFab
     {
         if (input.size() == 0)
         {
-            output = Json::Value::null;
+            output = Json::Value();
         }
         else
         {
@@ -227,7 +227,7 @@ namespace PlayFab
     template <typename EnumType> inline void FromJsonUtilE(const Json::Value& input, std::list<EnumType>& output)
     {
         output.clear();
-        if (input == Json::Value::null)
+        if (input == Json::Value())
         {
             return;
         }
@@ -254,7 +254,7 @@ namespace PlayFab
     template <typename EnumType> inline void FromJsonUtilE(const Json::Value& input, std::map<std::string, EnumType>& output)
     {
         output.clear();
-        if (input == Json::Value::null)
+        if (input == Json::Value())
         {
             return;
         }
@@ -272,7 +272,7 @@ namespace PlayFab
     {
         if (input.length() == 0)
         {
-            output = Json::Value::null;
+            output = Json::Value();
         }
         else
         {
@@ -282,7 +282,7 @@ namespace PlayFab
 
     inline void FromJsonUtilS(const Json::Value& input, std::string& output)
     {
-        if (input == Json::Value::null)
+        if (input == Json::Value())
         {
             output.clear();
         }
@@ -296,7 +296,7 @@ namespace PlayFab
     {
         if (input.size() == 0)
         {
-            output = Json::Value::null;
+            output = Json::Value();
         }
         else
         {
@@ -314,7 +314,7 @@ namespace PlayFab
     inline void FromJsonUtilS(const Json::Value& input, std::list<std::string>& output)
     {
         output.clear();
-        if (input == Json::Value::null)
+        if (input == Json::Value())
         {
             return;
         }
@@ -341,7 +341,7 @@ namespace PlayFab
     inline void FromJsonUtilS(const Json::Value& input, std::map<std::string, std::string>& output)
     {
         output.clear();
-        if (input == Json::Value::null)
+        if (input == Json::Value())
         {
             return;
         }
@@ -379,7 +379,7 @@ namespace PlayFab
 
     template <typename ObjectType> inline void FromJsonUtilO(const Json::Value& input, Boxed<ObjectType>& output)
     {
-        if (input == Json::Value::null)
+        if (input == Json::Value())
         {
             output.setNull();
         }
@@ -395,7 +395,7 @@ namespace PlayFab
     {
         if (input.size() == 0)
         {
-            output = Json::Value::null;
+            output = Json::Value();
         }
         else
         {
@@ -413,7 +413,7 @@ namespace PlayFab
     template <typename ObjectType> inline void FromJsonUtilO(const Json::Value& input, std::list<ObjectType>& output)
     {
         output.clear();
-        if (input == Json::Value::null)
+        if (input == Json::Value())
         {
             return;
         }
@@ -440,7 +440,7 @@ namespace PlayFab
     template <typename ObjectType> inline void FromJsonUtilO(const Json::Value& input, std::map<std::string, ObjectType>& output)
     {
         output.clear();
-        if (input == Json::Value::null)
+        if (input == Json::Value())
         {
             return;
         }
@@ -461,47 +461,47 @@ namespace PlayFab
 
     inline void FromJsonUtilP(const Json::Value& input, bool& output)
     {
-        output = input == Json::Value::null ? false : input.asBool();
+        output = input == Json::Value() ? false : input.asBool();
     }
 
     inline void FromJsonUtilP(const Json::Value& input, Int16& output)
     {
-        output = input == Json::Value::null ? 0 : static_cast<Int16>(input.asInt());
+        output = input == Json::Value() ? 0 : static_cast<Int16>(input.asInt());
     }
 
     inline void FromJsonUtilP(const Json::Value& input, Uint16& output)
     {
-        output = input == Json::Value::null ? static_cast<Uint16>(0) : static_cast<Uint16>(input.asInt());
+        output = input == Json::Value() ? static_cast<Uint16>(0) : static_cast<Uint16>(input.asInt());
     }
 
     inline void FromJsonUtilP(const Json::Value& input, Int32& output)
     {
-        output = input == Json::Value::null ? 0 : input.asInt();
+        output = input == Json::Value() ? 0 : input.asInt();
     }
 
     inline void FromJsonUtilP(const Json::Value& input, Uint32& output)
     {
-        output = input == Json::Value::null ? 0 : input.asUInt();
+        output = input == Json::Value() ? 0 : input.asUInt();
     }
 
     inline void FromJsonUtilP(const Json::Value& input, Int64& output)
     {
-        output = input == Json::Value::null ? 0 : input.asInt64();
+        output = input == Json::Value() ? 0 : input.asInt64();
     }
 
     inline void FromJsonUtilP(const Json::Value& input, Uint64& output)
     {
-        output = input == Json::Value::null ? 0 : input.asUInt64();
+        output = input == Json::Value() ? 0 : input.asUInt64();
     }
 
     inline void FromJsonUtilP(const Json::Value& input, float& output)
     {
-        output = input == Json::Value::null ? 0 : input.asFloat();
+        output = input == Json::Value() ? 0 : input.asFloat();
     }
 
     inline void FromJsonUtilP(const Json::Value& input, double& output)
     {
-        output = input == Json::Value::null ? 0 : input.asDouble();
+        output = input == Json::Value() ? 0 : input.asDouble();
     }
 
     template <typename PrimitiveType> inline void ToJsonUtilP(const Boxed<PrimitiveType>& input, Json::Value& output)
@@ -518,7 +518,7 @@ namespace PlayFab
 
     template <typename PrimitiveType> inline void FromJsonUtilP(const Json::Value& input, Boxed<PrimitiveType>& output)
     {
-        if (input == Json::Value::null)
+        if (input == Json::Value())
         {
             output.setNull();
         }
@@ -534,7 +534,7 @@ namespace PlayFab
     {
         if (input.size() == 0)
         {
-            output = Json::Value::null;
+            output = Json::Value();
         }
         else
         {
@@ -552,7 +552,7 @@ namespace PlayFab
     template <typename PrimitiveType> inline void FromJsonUtilP(const Json::Value& input, std::list<PrimitiveType>& output)
     {
         output.clear();
-        if (input == Json::Value::null)
+        if (input == Json::Value())
         {
             return;
         }
@@ -579,7 +579,7 @@ namespace PlayFab
     template <typename PrimitiveType> inline void FromJsonUtilP(const Json::Value& input, std::map<std::string, PrimitiveType>& output)
     {
         output.clear();
-        if (input == Json::Value::null)
+        if (input == Json::Value())
         {
             return;
         }

--- a/code/include/playfab/PlayFabCallRequestContainer.h
+++ b/code/include/playfab/PlayFabCallRequestContainer.h
@@ -33,7 +33,7 @@ namespace PlayFab
 
         bool finished;
         std::string responseString;
-        Json::Value responseJson = Json::Value::null;
+        Json::Value responseJson = Json::Value();
         std::string requestId;
         PlayFabError errorWrapper;
         std::shared_ptr<void> successCallback;

--- a/code/source/playfab/PlayFabAndroidHttpPlugin.cpp
+++ b/code/source/playfab/PlayFabAndroidHttpPlugin.cpp
@@ -684,14 +684,14 @@ namespace PlayFab
         if (parsedSuccessfully)
         {
             // fully successful response
-            requestContainer.errorWrapper.HttpCode = requestContainer.responseJson.get("code", Json::Value::null).asInt();
-            requestContainer.errorWrapper.HttpStatus = requestContainer.responseJson.get("status", Json::Value::null).asString();
-            requestContainer.errorWrapper.Data = requestContainer.responseJson.get("data", Json::Value::null);
-            requestContainer.errorWrapper.ErrorName = requestContainer.responseJson.get("error", Json::Value::null).asString();
-            requestContainer.errorWrapper.ErrorCode = static_cast<PlayFabErrorCode>(requestContainer.responseJson.get("errorCode", Json::Value::null).asInt());
-            requestContainer.errorWrapper.ErrorMessage = requestContainer.responseJson.get("errorMessage", Json::Value::null).asString();
-            requestContainer.errorWrapper.ErrorDetails = requestContainer.responseJson.get("errorDetails", Json::Value::null);
-            requestContainer.errorWrapper.RetryAfterSeconds = requestContainer.responseJson.get("retryAfterSeconds", Json::Value::null);
+            requestContainer.errorWrapper.HttpCode = requestContainer.responseJson.get("code", Json::Value()).asInt();
+            requestContainer.errorWrapper.HttpStatus = requestContainer.responseJson.get("status", Json::Value()).asString();
+            requestContainer.errorWrapper.Data = requestContainer.responseJson.get("data", Json::Value());
+            requestContainer.errorWrapper.ErrorName = requestContainer.responseJson.get("error", Json::Value()).asString();
+            requestContainer.errorWrapper.ErrorCode = static_cast<PlayFabErrorCode>(requestContainer.responseJson.get("errorCode", Json::Value()).asInt());
+            requestContainer.errorWrapper.ErrorMessage = requestContainer.responseJson.get("errorMessage", Json::Value()).asString();
+            requestContainer.errorWrapper.ErrorDetails = requestContainer.responseJson.get("errorDetails", Json::Value());
+            requestContainer.errorWrapper.RetryAfterSeconds = requestContainer.responseJson.get("retryAfterSeconds", Json::Value());
         }
         else
         {
@@ -710,7 +710,7 @@ namespace PlayFab
         CallRequestContainerCallback callback = requestContainer.GetCallback();
         if (callback != nullptr)
         {
-            callback(requestContainer.responseJson.get("code", Json::Value::null).asInt(),
+            callback(requestContainer.responseJson.get("code", Json::Value()).asInt(),
                      requestContainer.responseString,
                      std::unique_ptr<CallRequestContainerBase>(static_cast<CallRequestContainerBase*>(requestTask.requestContainer.release())));
         }

--- a/code/source/playfab/PlayFabCallRequestContainer.cpp
+++ b/code/source/playfab/PlayFabCallRequestContainer.cpp
@@ -15,7 +15,7 @@
             CallRequestContainerBase(url, headers, requestBody, callback, customData),
             finished(false),
             responseString(""),
-            responseJson(Json::Value::null),
+            responseJson(Json::Value()),
             errorWrapper(),
             successCallback(nullptr),
             errorCallback(nullptr),

--- a/code/source/playfab/PlayFabCurlHttpPlugin.cpp
+++ b/code/source/playfab/PlayFabCurlHttpPlugin.cpp
@@ -241,14 +241,14 @@ namespace PlayFab
 
             if (parsedSuccessfully)
             {
-                reqContainer.errorWrapper.HttpCode = reqContainer.responseJson.get("code", Json::Value::null).asInt();
-                reqContainer.errorWrapper.HttpStatus = reqContainer.responseJson.get("status", Json::Value::null).asString();
-                reqContainer.errorWrapper.Data = reqContainer.responseJson.get("data", Json::Value::null);
-                reqContainer.errorWrapper.ErrorName = reqContainer.responseJson.get("error", Json::Value::null).asString();
-                reqContainer.errorWrapper.ErrorCode = static_cast<PlayFabErrorCode>(reqContainer.responseJson.get("errorCode", Json::Value::null).asInt());
-                reqContainer.errorWrapper.ErrorMessage = reqContainer.responseJson.get("errorMessage", Json::Value::null).asString();
-                reqContainer.errorWrapper.ErrorDetails = reqContainer.responseJson.get("errorDetails", Json::Value::null);
-                reqContainer.errorWrapper.RetryAfterSeconds = reqContainer.responseJson.get("retryAfterSeconds", Json::Value::null);
+                reqContainer.errorWrapper.HttpCode = reqContainer.responseJson.get("code", Json::Value()).asInt();
+                reqContainer.errorWrapper.HttpStatus = reqContainer.responseJson.get("status", Json::Value()).asString();
+                reqContainer.errorWrapper.Data = reqContainer.responseJson.get("data", Json::Value());
+                reqContainer.errorWrapper.ErrorName = reqContainer.responseJson.get("error", Json::Value()).asString();
+                reqContainer.errorWrapper.ErrorCode = static_cast<PlayFabErrorCode>(reqContainer.responseJson.get("errorCode", Json::Value()).asInt());
+                reqContainer.errorWrapper.ErrorMessage = reqContainer.responseJson.get("errorMessage", Json::Value()).asString();
+                reqContainer.errorWrapper.ErrorDetails = reqContainer.responseJson.get("errorDetails", Json::Value());
+                reqContainer.errorWrapper.RetryAfterSeconds = reqContainer.responseJson.get("retryAfterSeconds", Json::Value());
             }
             else
             {
@@ -274,7 +274,7 @@ namespace PlayFab
         if (callback != nullptr)
         {
             callback(
-                reqContainer.responseJson.get("code", Json::Value::null).asInt(),
+                reqContainer.responseJson.get("code", Json::Value()).asInt(),
                 reqContainer.responseString,
                 std::unique_ptr<CallRequestContainerBase>(static_cast<CallRequestContainerBase*>(requestContainer.release())));
         }

--- a/code/source/playfab/PlayFabError.cpp
+++ b/code/source/playfab/PlayFabError.cpp
@@ -7,31 +7,31 @@ namespace PlayFab
     void PlayFabError::FromJson(const Json::Value& input)
     {
         const Json::Value HttpCode_member = input["code"];
-        if (HttpCode_member != Json::Value::null)
+        if (HttpCode_member != Json::Value())
         {
             HttpCode = HttpCode_member.asInt();
         }
 
         const Json::Value ErrorCode_member = input["errorCode"];
-        if (ErrorCode_member != Json::Value::null)
+        if (ErrorCode_member != Json::Value())
         {
             ErrorCode = PlayFabErrorCode(ErrorCode_member.asInt());
         }
 
         const Json::Value HttpStatus_member = input["status"];
-        if (HttpStatus_member != Json::Value::null)
+        if (HttpStatus_member != Json::Value())
         {
             HttpStatus = HttpStatus_member.asString();
         }
 
         const Json::Value ErrorName_member = input["error"];
-        if (ErrorName_member != Json::Value::null)
+        if (ErrorName_member != Json::Value())
         {
             ErrorName = ErrorName_member.asString();
         }
 
         const Json::Value ErrorMessage_member = input["errorMessage"];
-        if (ErrorMessage_member != Json::Value::null)
+        if (ErrorMessage_member != Json::Value())
         {
             ErrorMessage = ErrorMessage_member.asString();
         }
@@ -61,7 +61,7 @@ namespace PlayFab
         std::string output;
         output.reserve(1024);
         output += ErrorMessage;
-        if (ErrorDetails != Json::Value::null && ErrorDetails.isObject())
+        if (ErrorDetails != Json::Value() && ErrorDetails.isObject())
         {
             for (auto detailIter = ErrorDetails.begin(); detailIter != ErrorDetails.end(); ++detailIter)
             {

--- a/code/source/playfab/PlayFabIOSHttpPlugin.mm
+++ b/code/source/playfab/PlayFabIOSHttpPlugin.mm
@@ -321,14 +321,14 @@ namespace PlayFab
         if (parsedSuccessfully)
         {
             // fully successful response
-            requestContainer.errorWrapper.HttpCode = requestContainer.responseJson.get("code", Json::Value::null).asInt();
-            requestContainer.errorWrapper.HttpStatus = requestContainer.responseJson.get("status", Json::Value::null).asString();
-            requestContainer.errorWrapper.Data = requestContainer.responseJson.get("data", Json::Value::null);
-            requestContainer.errorWrapper.ErrorName = requestContainer.responseJson.get("error", Json::Value::null).asString();
-            requestContainer.errorWrapper.ErrorCode = static_cast<PlayFabErrorCode>(requestContainer.responseJson.get("errorCode", Json::Value::null).asInt());
-            requestContainer.errorWrapper.ErrorMessage = requestContainer.responseJson.get("errorMessage", Json::Value::null).asString();
-            requestContainer.errorWrapper.ErrorDetails = requestContainer.responseJson.get("errorDetails", Json::Value::null);
-            requestContainer.errorWrapper.RetryAfterSeconds = requestContainer.responseJson.get("retryAfterSeconds", Json::Value::null);
+            requestContainer.errorWrapper.HttpCode = requestContainer.responseJson.get("code", Json::Value()).asInt();
+            requestContainer.errorWrapper.HttpStatus = requestContainer.responseJson.get("status", Json::Value()).asString();
+            requestContainer.errorWrapper.Data = requestContainer.responseJson.get("data", Json::Value());
+            requestContainer.errorWrapper.ErrorName = requestContainer.responseJson.get("error", Json::Value()).asString();
+            requestContainer.errorWrapper.ErrorCode = static_cast<PlayFabErrorCode>(requestContainer.responseJson.get("errorCode", Json::Value()).asInt());
+            requestContainer.errorWrapper.ErrorMessage = requestContainer.responseJson.get("errorMessage", Json::Value()).asString();
+            requestContainer.errorWrapper.ErrorDetails = requestContainer.responseJson.get("errorDetails", Json::Value());
+            requestContainer.errorWrapper.RetryAfterSeconds = requestContainer.responseJson.get("retryAfterSeconds", Json::Value());
         }
         else
         {
@@ -347,7 +347,7 @@ namespace PlayFab
         const auto& callback = requestContainer.GetCallback();
         if (callback != nullptr)
         {
-            callback(requestContainer.responseJson.get("code", Json::Value::null).asInt(),
+            callback(requestContainer.responseJson.get("code", Json::Value()).asInt(),
                      requestContainer.responseString,
                      std::unique_ptr<CallRequestContainerBase>(static_cast<CallRequestContainerBase*>(requestTask.requestContainer.release())));
         }

--- a/code/source/playfab/PlayFabIXHR2HttpPlugin.cpp
+++ b/code/source/playfab/PlayFabIXHR2HttpPlugin.cpp
@@ -214,14 +214,14 @@ namespace PlayFab
 
             if (parsedSuccessfully)
             {
-                reqContainer.errorWrapper.HttpCode = reqContainer.responseJson.get("code", Json::Value::null).asInt();
-                reqContainer.errorWrapper.HttpStatus = reqContainer.responseJson.get("status", Json::Value::null).asString();
-                reqContainer.errorWrapper.Data = reqContainer.responseJson.get("data", Json::Value::null);
-                reqContainer.errorWrapper.ErrorName = reqContainer.responseJson.get("error", Json::Value::null).asString();
-                reqContainer.errorWrapper.ErrorCode = static_cast<PlayFabErrorCode>(reqContainer.responseJson.get("errorCode", Json::Value::null).asInt());
-                reqContainer.errorWrapper.ErrorMessage = reqContainer.responseJson.get("errorMessage", Json::Value::null).asString();
-                reqContainer.errorWrapper.ErrorDetails = reqContainer.responseJson.get("errorDetails", Json::Value::null);
-                reqContainer.errorWrapper.RetryAfterSeconds = reqContainer.responseJson.get("retryAfterSeconds", Json::Value::null);
+                reqContainer.errorWrapper.HttpCode = reqContainer.responseJson.get("code", Json::Value()).asInt();
+                reqContainer.errorWrapper.HttpStatus = reqContainer.responseJson.get("status", Json::Value()).asString();
+                reqContainer.errorWrapper.Data = reqContainer.responseJson.get("data", Json::Value());
+                reqContainer.errorWrapper.ErrorName = reqContainer.responseJson.get("error", Json::Value()).asString();
+                reqContainer.errorWrapper.ErrorCode = static_cast<PlayFabErrorCode>(reqContainer.responseJson.get("errorCode", Json::Value()).asInt());
+                reqContainer.errorWrapper.ErrorMessage = reqContainer.responseJson.get("errorMessage", Json::Value()).asString();
+                reqContainer.errorWrapper.ErrorDetails = reqContainer.responseJson.get("errorDetails", Json::Value());
+                reqContainer.errorWrapper.RetryAfterSeconds = reqContainer.responseJson.get("retryAfterSeconds", Json::Value());
             }
             else
             {
@@ -243,7 +243,7 @@ namespace PlayFab
         if (callback != nullptr)
         {
             callback(
-                reqContainer.responseJson.get("code", Json::Value::null).asInt(),
+                reqContainer.responseJson.get("code", Json::Value()).asInt(),
                 reqContainer.responseString,
                 std::unique_ptr<CallRequestContainerBase>(static_cast<CallRequestContainerBase*>(requestContainer.release())));
         }

--- a/code/source/playfab/PlayFabWinHttpPlugin.cpp
+++ b/code/source/playfab/PlayFabWinHttpPlugin.cpp
@@ -424,14 +424,14 @@ namespace PlayFab
         if (parsedSuccessfully)
         {
             // fully successful response
-            reqContainer.errorWrapper.HttpCode = reqContainer.responseJson.get("code", Json::Value::null).asInt();
-            reqContainer.errorWrapper.HttpStatus = reqContainer.responseJson.get("status", Json::Value::null).asString();
-            reqContainer.errorWrapper.Data = reqContainer.responseJson.get("data", Json::Value::null);
-            reqContainer.errorWrapper.ErrorName = reqContainer.responseJson.get("error", Json::Value::null).asString();
-            reqContainer.errorWrapper.ErrorCode = static_cast<PlayFabErrorCode>(reqContainer.responseJson.get("errorCode", Json::Value::null).asInt());
-            reqContainer.errorWrapper.ErrorMessage = reqContainer.responseJson.get("errorMessage", Json::Value::null).asString();
-            reqContainer.errorWrapper.ErrorDetails = reqContainer.responseJson.get("errorDetails", Json::Value::null);
-            reqContainer.errorWrapper.RetryAfterSeconds = reqContainer.responseJson.get("retryAfterSeconds", Json::Value::null);
+            reqContainer.errorWrapper.HttpCode = reqContainer.responseJson.get("code", Json::Value()).asInt();
+            reqContainer.errorWrapper.HttpStatus = reqContainer.responseJson.get("status", Json::Value()).asString();
+            reqContainer.errorWrapper.Data = reqContainer.responseJson.get("data", Json::Value());
+            reqContainer.errorWrapper.ErrorName = reqContainer.responseJson.get("error", Json::Value()).asString();
+            reqContainer.errorWrapper.ErrorCode = static_cast<PlayFabErrorCode>(reqContainer.responseJson.get("errorCode", Json::Value()).asInt());
+            reqContainer.errorWrapper.ErrorMessage = reqContainer.responseJson.get("errorMessage", Json::Value()).asString();
+            reqContainer.errorWrapper.ErrorDetails = reqContainer.responseJson.get("errorDetails", Json::Value());
+            reqContainer.errorWrapper.RetryAfterSeconds = reqContainer.responseJson.get("retryAfterSeconds", Json::Value());
         }
         else
         {
@@ -461,7 +461,7 @@ namespace PlayFab
         if (callback != nullptr)
         {
             callback(
-                reqContainer.responseJson.get("code", Json::Value::null).asInt(),
+                reqContainer.responseJson.get("code", Json::Value()).asInt(),
                 reqContainer.responseString,
                 std::unique_ptr<CallRequestContainerBase>(static_cast<CallRequestContainerBase*>(requestContainer.release())));
         }


### PR DESCRIPTION
Replaced all usages of Json::Value::null with Json::Value() (default constructor) across the PlayFab SDK source and commented out the deprecated static declarations/definitions in the jsoncpp submodule.